### PR TITLE
chore: ignore JetBrains IDE config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage.out
 .env
 clearingway
 !clearingway/
+.idea/


### PR DESCRIPTION
[Explanation](https://stackoverflow.com/questions/17049416/what-is-the-idea-folder) on what the folder is and why it should be excluded.

tl;dr - It's used by GoLand to store the project config for an individual dev's setup