### PR TITLE
fix: limit pdoc role to ultimates

### DIFF
--- a/internal/clearingway/relevant-reptition-roles.go
+++ b/internal/clearingway/relevant-reptition-roles.go
@@ -14,6 +14,11 @@ func RelevantRepetitionRoles(encs *Encounters) *Roles {
 			Description: "Cleared any relevant encounter at least 100 times.",
 			ShouldApply: func(opts *ShouldApplyOpts) (bool, string) {
 				for _, encounter := range opts.Encounters.Encounters {
+					// Only consider Ultimate encounters for this role
+					if encounter.Difficulty != "Ultimate" {
+						continue
+					}
+
 					clears := 0
 
 					for _, encounterId := range encounter.Ids {


### PR DESCRIPTION
We're currently giving "Please Do Other Content" to anyone who clears _any_ tracked content 100 times. Since we're now tracking savage per combining with NASE, we should filter out non-ultimate encounters.