### PR TITLE
Increment M12S Boss ID

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -423,7 +423,7 @@ guilds:
         type: "Prog"
       - name: "M11S C4X"
         type: "C4X"
-  - ids: [104]  # should be 105 if there's a doorboss
+  - ids: [105]  # should be 105 if there's a doorboss
     name: "M12S"
     defaultRoles: false
     difficulty: "Savage"


### PR DESCRIPTION
As M12S is a door boss, we have to increment the fight ID to check if
people cleared the entire fight, and not just the door boss.

Ticket naurffxiv/naur#68 