### PR TITLE
chore: disable perm grant on role ensure

### DIFF
--- a/internal/clearingway/role.go
+++ b/internal/clearingway/role.go
@@ -70,6 +70,7 @@ func (r *Role) Ensure(guildId string, s *discordgo.Session, existingRoles []*dis
 	roleParams := &discordgo.RoleParams{
 		Name:  r.Name,
 		Color: &r.Color,
+		Permissions: &[]int64{0}[0], // No permissions
 	}
 
 	if r.Hoist {


### PR DESCRIPTION
Prevents Ensured roles from having any permissions by using a full 0 bitmask