### PR TITLE
feat: add support for kefka ulti

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -277,17 +277,17 @@ guilds:
     the: "Mad"
     difficulty: "Ultimate"
     roles:
-      - name: "DMU Cleared"
+      - name: "UMAD Cleared"
         type: "Cleared"
         color: 0xfc97f8
-      - name: "DMU Reclear"
+      - name: "UMAD Reclear"
         type: "Reclear"
-      - name: "DMU Color"
+      - name: "UMAD Color"
         type: "Name Color"
         color: 0xfc97f8
-      - name: "DMU C4X"
+      - name: "UMAD C4X"
         type: "C4X"
-      - name: "DMU Prog"
+      - name: "UMAD Prog"
         type: "Prog"
   - ids: [1079]
     name: "Futures Rewritten (Ultimate)"

--- a/config.yaml
+++ b/config.yaml
@@ -270,6 +270,25 @@ guilds:
   guildId: 1172230157776466050
   channelId: 1172348608671133760
   encounters:
+  - ids: [1085]
+    name: "Dancing Mad (Ultimate)"
+    defaultRoles: false
+    totalWeaponsAvailable: 21
+    the: "Mad"
+    difficulty: "Ultimate"
+    roles:
+      - name: "DMU Cleared"
+        type: "Cleared"
+        color: 0xfc97f8
+      - name: "DMU Reclear"
+        type: "Reclear"
+      - name: "DMU Color"
+        type: "Name Color"
+        color: 0xfc97f8
+      - name: "DMU C4X"
+        type: "C4X"
+      - name: "DMU Prog"
+        type: "Prog"
   - ids: [1079]
     name: "Futures Rewritten (Ultimate)"
     defaultRoles: false
@@ -477,6 +496,10 @@ guilds:
     type: "Limbo"
     encounterName: "Futures Rewritten (Ultimate)"
     skip: true
+  - from: "Limbo"
+    type: "Limbo"
+    encounterName: "Dancing Mad (Ultimate)"
+    skip: true
   - from: "NA's Comfiest"
     skip: true
   - from: "The Comfy Legend"
@@ -506,6 +529,10 @@ guilds:
     type: "Complete"
     encounterName: "Futures Rewritten (Ultimate)"
     to: "Roommate"
+  - from: "Complete"
+    type: "Complete"
+    encounterName: "Dancing Mad (Ultimate)"
+    to: "Mad"
   menuOrder:
     - name: "roleAssignment"
       menus:

--- a/internal/clearingway/encounter.go
+++ b/internal/clearingway/encounter.go
@@ -58,6 +58,14 @@ var UltimateEncounters = &Encounters{
 			TotalWeaponsAvailable: 21,
 			The:                   "Roommate",
 		},
+		{
+			Name:                  "Dancing Mad (Ultimate)",
+			Ids:                   []int{1085},
+			Difficulty:            "Ultimate",
+			DefaultRoles:          false,
+			TotalWeaponsAvailable: 21,
+			The:                   "Mad",
+		},
 	},
 }
 

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -239,7 +239,7 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 					Value: "Futures Rewritten (Ultimate)",
 				},
 				{
-					Name:  "DMU",
+					Name:  "UMAD",
 					Value: "Dancing Mad (Ultimate)",
 				},
 			},
@@ -282,7 +282,7 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 					Value: "Futures Rewritten (Ultimate)",
 				},
 				{
-					Name:  "DMU",
+					Name:  "UMAD",
 					Value: "Dancing Mad (Ultimate)",
 				},
 			},

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -238,6 +238,10 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 					Name:  "FRU",
 					Value: "Futures Rewritten (Ultimate)",
 				},
+				{
+					Name:  "DMU",
+					Value: "Dancing Mad (Ultimate)",
+				},
 			},
 		},
 	},
@@ -276,6 +280,10 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 				{
 					Name:  "FRU",
 					Value: "Futures Rewritten (Ultimate)",
+				},
+				{
+					Name:  "DMU",
+					Value: "Dancing Mad (Ultimate)",
 				},
 			},
 		},

--- a/internal/clearingway/legend-roles.go
+++ b/internal/clearingway/legend-roles.go
@@ -37,6 +37,8 @@ func legendRoleString(clearedEncounters *Encounters, rankings *fflogs.Rankings) 
 			"=3", "Cleared the following three Ultimate fights:\n",
 			"=4", "Cleared the following four Ultimate fights:\n",
 			"=5", "Cleared the following five Ultimate fights:\n",
+			"=6", "Cleared the following six Ultimate fights:\n",
+			"=7", "Cleared the following seven Ultimate fights:\n",
 			"other", "Cleared the following Ultimate fights:\n",
 		),
 	)
@@ -137,7 +139,20 @@ func LegendRoles() *Roles {
 					return true, output
 				}
 
-				return false, "Did not clear all six ultimates."
+				return false, "Did not clear only six ultimates."
+			},
+		},
+		{
+			Name: "The Septuple Legend", Color: 0x3498db,
+			Description: "Cleared all seven ultimates.",
+			ShouldApply: func(opts *ShouldApplyOpts) (bool, string) {
+				clearedEncounters := opts.Encounters.Clears(opts.Rankings)
+				if len(clearedEncounters.Encounters) == 7 {
+					output := legendRoleString(clearedEncounters, opts.Rankings)
+					return true, output
+				}
+
+				return false, "Did not clear all seven ultimates."
 			},
 		},
 		{


### PR DESCRIPTION
Closes: https://github.com/naurffxiv/naur/issues/392

Adds support to CW for the new DT ulti feat. Kefka. Includes the usual roles as well as the new Septuple role.