### PR TITLE
fix(fflogs): handle nil deref when ranking doesn't exist

### DIFF
--- a/internal/fflogs/graphql.go
+++ b/internal/fflogs/graphql.go
@@ -185,6 +185,9 @@ func (f *Fflogs) GetRankingsForCharacter(rankingsToGet []*RankingToGet, char *ff
 		if partition == "nonstandard" {
 			ranking.Nonstandard = true
 		}
+		if rawRanking == nil {
+			continue // fflogs returns nil for rankings that don't exist
+		}
 		err = json.Unmarshal(*rawRanking, ranking)
 		if err != nil {
 			return nil, fmt.Errorf("Could not unmarshal JSON: %w", err)


### PR DESCRIPTION
Previously, we were attempting to unmarshal a nil value due to fflogs returning nil for rankings that don't exist. We now skip those since the data isn't available and we can't count on the rankings having existed in the first place.

Resolves RADAR's issue with verification